### PR TITLE
Add optional delimiter for datasource export

### DIFF
--- a/src/controllers/ReportsController.php
+++ b/src/controllers/ReportsController.php
@@ -476,8 +476,9 @@ class ReportsController extends SharedController
                 $dataSource->isExport = true;
                 $labels = $dataSource->getDefaultLabels($report, $settings);
                 $values = $dataSource->getResults($report, $settings);
+                $delimiter = $report->getSettings()['delimiter'] ?? null;
 
-                SproutBaseReports::$app->exports->toCsv($values, $labels, $filename);
+                SproutBaseReports::$app->exports->toCsv($values, $labels, $filename, $delimiter);
             }
         }
     }

--- a/src/services/Exports.php
+++ b/src/services/Exports.php
@@ -60,11 +60,12 @@ class Exports extends Component
     /**
      * Takes an array of values and options labels and creates a downloadable CSV file
      *
-     * @param array  $values
-     * @param array  $labels
-     * @param string $filename
+     * @param array         $values
+     * @param array         $labels
+     * @param string        $filename
+     * @param string|null   $delimiter
      */
-    public function toCsv(array &$values, array $labels = [], $filename = 'export.csv')
+    public function toCsv(array &$values, array $labels = [], $filename = 'export.csv', $delimiter = null)
     {
         $filename = str_replace('.csv', '', $filename).'.csv';
 
@@ -76,6 +77,10 @@ class Exports extends Component
         }
 
         $csv = Writer::createFromFileObject(new SplTempFileObject());
+
+        if ($delimiter) {
+            $csv->setDelimiter($delimiter);
+        }
 
         $csv->insertOne($labels);
         $csv->insertAll($values);


### PR DESCRIPTION
When exporting results from a datasource to CSV the delimiter is set to , by default. Some OS have another delimiter (e.g. ;) set as default delimiter for CSV - files. By adding a delimiter option to the report users can choose which delimiter should be used when making an export.

For existing reports the default (,) delimiter is used.

Also see [this PR](https://github.com/barrelstrength/craft-sprout-forms/pull/470).